### PR TITLE
Add a CLI option to force becoming when running Ansible

### DIFF
--- a/src/clamav_report/clamav_report.py
+++ b/src/clamav_report/clamav_report.py
@@ -286,9 +286,9 @@ def main() -> None:
     logging.info("Gathering ClamAV data from remote servers.")
     results = run_ansible(
         inventory_filename=validated_args["<inventory-file>"],
+        become=validated_args["--become"],
         hosts=validated_args["--group"],
         forks=validated_args["--forks"],
-        become=validated_args["--become"],
     )
 
     csv_data = []

--- a/src/clamav_report/clamav_report.py
+++ b/src/clamav_report/clamav_report.py
@@ -5,6 +5,7 @@ Usage:
   clamav-report (-h | --help)
 
 Options:
+  -b --become            Become root when executing Ansible tasks.
   -f --forks=COUNT       Number of hosts to process in parallel. [default: 10]
   -g --group=GROUP       Inventory host group to access. [default: all]
   -h --help              Show this message.
@@ -109,7 +110,7 @@ class ResultCallback(CallbackBase):
         logging.error(f"Task callback FAILED: {result._host.name} - {result.task_name}")
 
 
-def run_ansible(inventory_filename, hosts="all", forks=10):
+def run_ansible(inventory_filename, become=None, hosts="all", forks=10):
     """Run ansible with the provided inventory file and host group."""
     # Since the API is constructed for CLI it expects certain options to
     # always be set in the context object.
@@ -117,7 +118,7 @@ def run_ansible(inventory_filename, hosts="all", forks=10):
         connection="ssh",
         module_path=[],
         forks=forks,
-        become=None,
+        become=become,
         become_method="sudo",
         become_user=None,
         check=False,
@@ -287,6 +288,7 @@ def main() -> None:
         inventory_filename=validated_args["<inventory-file>"],
         hosts=validated_args["--group"],
         forks=validated_args["--forks"],
+        become=validated_args["--become"],
     )
 
     csv_data = []


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a CLI flag to force `become=yes` when running Ansible.

## 💭 Motivation and context ##

@dav3r noticed that he needed to force the Ansible tasks to run as `root` on our FreeIPA instances, so I added this CLI switch to allow that.

## 🧪 Testing ##

All `pre-commit` hooks and `pytest` tests pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
